### PR TITLE
Allow Minecraft 1.15.2 (besides 1.15.1)

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -43,7 +43,7 @@ to use alternative methods of travel when exploring.
 [[dependencies.magicfeather]]
     modId="minecraft"
     mandatory=true
-    versionRange="[1.15.1]"
+    versionRange="[1.15.1,)"
     ordering="NONE"
     side="BOTH"
 [[dependencies.magicfeather]]


### PR DESCRIPTION
This is to fix #9.

I tested it by updating mods.toml in my jar file and your mod was working flawlessly.
*Note*: Of course I also had to do this for your library mod (CookieCore). Should I open this as an issue/PR there too?

Due to my lack of knowledge of minecraft mod structures I do not know which files may also be needed to be updated, sorry.